### PR TITLE
Changing Internet Check URL and status code

### DIFF
--- a/_main.py
+++ b/_main.py
@@ -2,14 +2,15 @@ import requests
 import sys
 
 def test_internet():
-	test_url = 'https://www.google.com'
+	test_url = 'https://cxd.cisco.com/home'
 	response = None
 	print("Checking internet connectivity.")
 	try:
 		response = requests.get(test_url)
 	except Exception as e:
 		print("Unable to connect to internet. Make sure you have connectivity, and you have set the Proxy and DNS entries. \nError: " + str(e))
-	if  response is not None and response.status_code == 200:
+	if  response is not None and response.status_code == 401:
+		# If we are receiving a 401 response from the server, connection is OK
 		print("Internet check successful. Proceeding")
 		return True
 	else:


### PR DESCRIPTION
Earlier the check was on https://www.google.com. But customers usually block access to google.com. So changing the check to cxd.cisco.com/home, which is the actual URL used for upload.  cxd.cisco.com will give a 401 Response code, but it proves that TCP Port 443 to cxd.cisco.com is open.